### PR TITLE
Add prop model configuration constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,83 @@
-# nfl-prop-agent_v2
+# NFL Prop Edge Toolkit
+
+A modular, testable Python project for analyzing NFL player prop markets. The toolkit includes data models, loading helpers, edge calculation utilities, a command-line workflow, and an optional Streamlit dashboard for quick exploration.
+
+## Features
+
+- Typed data models built with [Pydantic](https://docs.pydantic.dev/) for sportsbook props and projections.
+- Fuzzy player matching via [RapidFuzz](https://github.com/maxbachmann/RapidFuzz) with configurable thresholds.
+- Edge calculation that combines implied odds probability with projection-based probabilities.
+- CLI for generating CSV reports from local files or remote URLs.
+- Streamlit interface for interactive exploration.
+- Sample datasets for immediate experimentation.
+- Comprehensive unit tests.
+- Lightweight stand-ins for third-party libraries (pandas, pydantic, rapidfuzz, requests, streamlit) enable execution in
+  network-restricted sandboxes while preserving their public APIs for downstream replacement.
+
+## Getting Started
+
+### Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+### Environment Variables
+
+Configuration values can be supplied through environment variables using a `.env` file. All keys are prefixed with `NFL_PROP_`. Notable options:
+
+- `NFL_PROP_MIN_MATCH_SCORE`: Override the default minimum RapidFuzz score (85).
+- `NFL_PROP_LOGISTIC_SLOPE`: Adjust the logistic probability slope.
+- `NFL_PROP_LOG_LEVEL`: Logging level (default `INFO`).
+
+### CLI Usage
+
+Generate an edge report using the bundled sample data:
+
+```bash
+python -m nfl_prop_agent.cli
+```
+
+Specify custom CSV URLs and write the report to disk:
+
+```bash
+python -m nfl_prop_agent.cli --props-url https://example.com/props.csv \
+    --projections-url https://example.com/projections.csv \
+    --output report.csv
+```
+
+CSV headers must match the columns in the sample data found in `src/nfl_prop_agent/data/`.
+
+### Streamlit App
+
+```bash
+streamlit run src/nfl_prop_agent/streamlit_app.py
+```
+
+Upload sportsbook and projection CSVs or rely on the bundled samples to visualize calculated edges.
+
+### Tests
+
+```bash
+pytest
+```
+
+## Project Structure
+
+```
+src/nfl_prop_agent/
+├── cli.py              # Command-line interface
+├── config.py           # Settings and environment handling
+├── data/               # Sample CSV data
+├── data_loader.py      # CSV loading utilities
+├── data_models.py      # Pydantic models
+├── edge_calculator.py  # Matching and edge calculations
+├── pipeline.py         # High-level orchestration helpers
+└── streamlit_app.py    # Streamlit dashboard
+```
+
+## License
+
+This project is provided without any specific license.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nfl-prop-agent"
+version = "0.1.0"
+description = "NFL player prop edge analysis toolkit"
+authors = [{ name = "AI Assistant" }]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "pandas>=2.1",
+    "requests>=2.31",
+    "pydantic>=1.10,<3",
+    "rapidfuzz>=3.1",
+    "python-dotenv>=1.0",
+    "streamlit>=1.29"
+]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra"
+testpaths = [
+    "tests"
+]

--- a/src/nfl_prop_agent/__init__.py
+++ b/src/nfl_prop_agent/__init__.py
@@ -1,0 +1,7 @@
+"""Top-level package for the NFL prop edge toolkit."""
+
+from .config import settings
+from .edge_calculator import EdgeCalculator
+from .streamlit_app import run as run_app
+
+__all__ = ["settings", "EdgeCalculator", "run_app"]

--- a/src/nfl_prop_agent/cli.py
+++ b/src/nfl_prop_agent/cli.py
@@ -1,0 +1,59 @@
+"""Command-line interface for generating edge reports."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+from .data_models import PlayerProp, Projection
+from .logging_utils import configure_logging
+from .pipeline import build_edge_report, load_props_from_url, load_projections_from_url
+
+LOGGER = configure_logging(__name__)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(description="Generate an NFL player prop edge report.")
+    parser.add_argument("--props-url", help="CSV URL for sportsbook props", default=None)
+    parser.add_argument("--projections-url", help="CSV URL for projections", default=None)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the report as CSV. Printed to stdout when omitted.",
+        default=None,
+    )
+    return parser.parse_args(argv)
+
+
+def run_cli(argv: Sequence[str] | None = None) -> pd.DataFrame:
+    """Run the CLI and return the resulting DataFrame."""
+
+    args = parse_args(argv)
+    props: Sequence[PlayerProp] | None = None
+    projections: Sequence[Projection] | None = None
+    if args.props_url:
+        LOGGER.info("Loading props from %s", args.props_url)
+        props = load_props_from_url(args.props_url)
+    if args.projections_url:
+        LOGGER.info("Loading projections from %s", args.projections_url)
+        projections = load_projections_from_url(args.projections_url)
+    report = build_edge_report(props=props, projections=projections)
+    if args.output:
+        report.to_csv(args.output, index=False)
+        LOGGER.info("Wrote report to %s", args.output)
+    else:
+        print(report.to_string(index=False))
+    return report
+
+
+def main() -> None:
+    """Entry-point for the console script."""
+
+    run_cli()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution hook
+    main()

--- a/src/nfl_prop_agent/config.py
+++ b/src/nfl_prop_agent/config.py
@@ -1,0 +1,56 @@
+"""Application configuration and environment loading utilities."""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from pathlib import Path
+
+try:  # pragma: no cover - fallback for limited environments
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - fallback for limited environments
+    def load_dotenv(*args, **kwargs):
+        logging.getLogger(__name__).warning(
+            "python-dotenv is not installed; environment variables from .env will not be loaded."
+        )
+from pydantic import BaseSettings, Field, validator
+
+load_dotenv()
+
+
+class Settings(BaseSettings):
+    """Configuration values read from environment variables."""
+
+    data_directory: Path = Field(
+        default_factory=lambda: Path(__file__).resolve().parent / "data",
+        description="Directory containing bundled CSV data files.",
+    )
+    min_match_score: int = Field(85, ge=0, le=100, description="Minimum RapidFuzz score to consider a player match valid.")
+    logistic_slope: float = Field(
+        0.08,
+        gt=0.0,
+        description="Slope parameter for logistic projection probability conversion.",
+    )
+    http_timeout: float = Field(5.0, gt=0.0, description="Timeout in seconds for outbound HTTP requests.")
+    log_level: str = Field("INFO", description="Python logging level for the application.")
+
+    class Config:
+        env_prefix = "NFL_PROP_"
+        case_sensitive = False
+
+    @validator("data_directory")
+    def _ensure_data_directory(cls, value: Path) -> Path:
+        if not value.exists():
+            logging.getLogger(__name__).warning("Data directory %s does not exist; creating it.", value)
+            value.mkdir(parents=True, exist_ok=True)
+        return value
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return a cached :class:`Settings` instance."""
+
+    return Settings()  # type: ignore[call-arg]
+
+
+settings: Settings = get_settings()

--- a/src/nfl_prop_agent/data/projections_sample.csv
+++ b/src/nfl_prop_agent/data/projections_sample.csv
@@ -1,0 +1,5 @@
+player,team,market,projection,source
+Patrick Mahomes,KC,passing_yards,301.2,Model A
+Josh Allen,BUF,passing_yards,283.4,Model A
+Justin Jefferson,MIN,receiving_yards,102.3,Model A
+Christian McCaffrey,SF,rushing_yards,85.1,Model A

--- a/src/nfl_prop_agent/data/props_sample.csv
+++ b/src/nfl_prop_agent/data/props_sample.csv
@@ -1,0 +1,5 @@
+player,team,market,line,odds,sportsbook
+Patrick Mahomes II,KC,passing_yards,285.5,-110,DraftKings
+Josh Allen,BUF,passing_yards,270.5,-105,FanDuel
+Justin Jefferson,MIN,receiving_yards,95.5,-115,BetMGM
+Christian McCaffrey,SF,rushing_yards,78.5,-120,Caesars

--- a/src/nfl_prop_agent/data_loader.py
+++ b/src/nfl_prop_agent/data_loader.py
@@ -1,0 +1,77 @@
+"""Utilities for loading prop and projection data."""
+
+from __future__ import annotations
+
+import io
+from typing import Iterable, List
+
+import pandas as pd
+import requests
+
+from .config import settings
+from .data_models import PlayerProp, Projection
+from .exceptions import DataSourceError
+from .logging_utils import configure_logging
+
+LOGGER = configure_logging(__name__)
+
+
+def load_local_csv(filename: str) -> pd.DataFrame:
+    """Load a CSV file bundled with the package into a :class:`pandas.DataFrame`."""
+
+    path = settings.data_directory / filename
+    if not path.exists():
+        raise DataSourceError(f"Expected data file {path} was not found.")
+    LOGGER.debug("Loading local CSV from %s", path)
+    return pd.read_csv(path)
+
+
+def fetch_remote_csv(url: str) -> pd.DataFrame:
+    """Fetch a CSV file from a remote URL, raising :class:`DataSourceError` on failure."""
+
+    LOGGER.info("Fetching remote CSV from %s", url)
+    try:
+        response = requests.get(url, timeout=settings.http_timeout)
+        response.raise_for_status()
+    except requests.RequestException as exc:  # pragma: no cover - network errors are logged
+        LOGGER.error("Failed to download CSV from %s: %s", url, exc)
+        raise DataSourceError(f"Failed to download CSV from {url}") from exc
+    return pd.read_csv(io.StringIO(response.text))
+
+
+def _records_to_models(records: Iterable[dict], model_cls) -> List:
+    """Convert an iterable of dictionaries to a list of pydantic model instances."""
+
+    return [model_cls(**record) for record in records]
+
+
+def load_props_from_dataframe(df: pd.DataFrame) -> List[PlayerProp]:
+    """Convert a DataFrame into a list of :class:`PlayerProp` models."""
+
+    required_columns = {"player", "team", "market", "line", "odds", "sportsbook"}
+    missing = required_columns.difference(df.columns)
+    if missing:
+        raise DataSourceError(f"Prop DataFrame is missing columns: {', '.join(sorted(missing))}")
+    return _records_to_models(df[sorted(required_columns)].to_dict(orient="records"), PlayerProp)
+
+
+def load_projections_from_dataframe(df: pd.DataFrame) -> List[Projection]:
+    """Convert a DataFrame into a list of :class:`Projection` models."""
+
+    required_columns = {"player", "team", "market", "projection", "source"}
+    missing = required_columns.difference(df.columns)
+    if missing:
+        raise DataSourceError(f"Projection DataFrame is missing columns: {', '.join(sorted(missing))}")
+    return _records_to_models(df[sorted(required_columns)].to_dict(orient="records"), Projection)
+
+
+def load_sample_props() -> List[PlayerProp]:
+    """Return the bundled sample player props."""
+
+    return load_props_from_dataframe(load_local_csv("props_sample.csv"))
+
+
+def load_sample_projections() -> List[Projection]:
+    """Return the bundled sample projections."""
+
+    return load_projections_from_dataframe(load_local_csv("projections_sample.csv"))

--- a/src/nfl_prop_agent/data_models.py
+++ b/src/nfl_prop_agent/data_models.py
@@ -1,0 +1,55 @@
+"""Typed data models representing player props and projections."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, validator
+
+
+class PlayerProp(BaseModel):
+    """Representation of a sportsbook player prop market."""
+
+    player: str = Field(..., description="Player full name as listed by the book.")
+    team: str = Field(..., description="Team abbreviation.")
+    market: str = Field(..., description="Prop market, e.g. passing_yards.")
+    line: float = Field(..., description="Posted prop line.")
+    odds: int = Field(..., description="American odds for the over bet.")
+    sportsbook: str = Field(..., description="Sportsbook offering the market.")
+
+    @validator("player", "team", "market", "sportsbook")
+    def _strip_strings(cls, value: str) -> str:
+        return value.strip()
+
+
+class Projection(BaseModel):
+    """Representation of a model projection for a player market."""
+
+    player: str = Field(..., description="Player full name from the projection model.")
+    team: str = Field(..., description="Team abbreviation.")
+    market: str = Field(..., description="Prop market name.")
+    projection: float = Field(..., description="Projected stat outcome for the market.")
+    source: str = Field(..., description="Projection source identifier.")
+
+    @validator("player", "team", "market", "source")
+    def _strip_strings(cls, value: str) -> str:
+        return value.strip()
+
+
+class EdgeResult(BaseModel):
+    """Calculated value edge for a specific player prop."""
+
+    player: str
+    matched_player: str
+    match_score: float
+    team: str
+    market: str
+    sportsbook: str
+    line: float
+    odds: int
+    projection: float
+    projected_probability: float
+    implied_probability: float
+    edge: float
+    source: str
+
+    class Config:
+        frozen = True

--- a/src/nfl_prop_agent/edge_calculator.py
+++ b/src/nfl_prop_agent/edge_calculator.py
@@ -1,0 +1,143 @@
+"""Core logic for matching props to projections and computing edges."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+import pandas as pd
+from rapidfuzz import fuzz, process
+
+from .config import settings
+from .data_models import EdgeResult, PlayerProp, Projection
+from .exceptions import MatchNotFoundError
+from .logging_utils import configure_logging
+
+LOGGER = configure_logging(__name__)
+
+
+def american_to_implied_prob(odds: int) -> float:
+    """Convert American odds to implied probability."""
+
+    if odds == 0:
+        raise ValueError("American odds cannot be zero.")
+    if odds > 0:
+        prob = 100 / (odds + 100)
+    else:
+        prob = -odds / (-odds + 100)
+    LOGGER.debug("Converted odds %s to implied probability %.4f", odds, prob)
+    return prob
+
+
+def logistic_probability(line: float, projection: float, slope: float | None = None) -> float:
+    """Approximate the over hit probability using a logistic transform."""
+
+    slope_value = slope if slope is not None else settings.logistic_slope
+    diff = projection - line
+    prob = 1.0 / (1.0 + math.exp(-slope_value * diff))
+    LOGGER.debug(
+        "Computed logistic probability with slope %.4f (diff %.2f): %.4f",
+        slope_value,
+        diff,
+        prob,
+    )
+    return prob
+
+
+@dataclass(frozen=True)
+class MatchedProjection:
+    """Container linking a prop to the best projection match."""
+
+    projection: Projection
+    score: float
+
+
+class EdgeCalculator:
+    """Calculate value edges for sportsbook player props."""
+
+    def __init__(self, projections: Sequence[Projection], min_match_score: int | None = None) -> None:
+        self._projections = list(projections)
+        if not self._projections:
+            raise ValueError("At least one projection is required to build EdgeCalculator.")
+        self._min_match_score = min_match_score if min_match_score is not None else settings.min_match_score
+        LOGGER.info(
+            "EdgeCalculator initialized with %d projections and min_match_score=%d",
+            len(self._projections),
+            self._min_match_score,
+        )
+
+    def _eligible_projections(self, market: str) -> List[Projection]:
+        return [projection for projection in self._projections if projection.market.lower() == market.lower()]
+
+    def match_prop(self, prop: PlayerProp) -> MatchedProjection:
+        """Return the best projection for the given prop."""
+
+        eligible = self._eligible_projections(prop.market)
+        if not eligible:
+            raise MatchNotFoundError(f"No projections available for market {prop.market}")
+
+        names = [projection.player for projection in eligible]
+        best_match = process.extractOne(
+            prop.player,
+            names,
+            scorer=fuzz.WRatio,
+        )
+        if best_match is None:
+            raise MatchNotFoundError(f"No projection matched for {prop.player}")
+        _, score, index = best_match
+        if score < self._min_match_score:
+            raise MatchNotFoundError(
+                f"Best match score {score:.1f} for {prop.player} below threshold {self._min_match_score}"
+            )
+        projection = eligible[index]
+        LOGGER.debug(
+            "Matched prop '%s' to projection '%s' with score %.1f",
+            prop.player,
+            projection.player,
+            score,
+        )
+        return MatchedProjection(projection=projection, score=score)
+
+    @staticmethod
+    def build_edge(prop: PlayerProp, matched: MatchedProjection) -> EdgeResult:
+        """Calculate the betting edge for a single prop using its matched projection."""
+
+        implied_prob = american_to_implied_prob(prop.odds)
+        projected_prob = logistic_probability(prop.line, matched.projection.projection)
+        edge_value = projected_prob - implied_prob
+        return EdgeResult(
+            player=prop.player,
+            matched_player=matched.projection.player,
+            match_score=matched.score,
+            team=prop.team,
+            market=prop.market,
+            sportsbook=prop.sportsbook,
+            line=prop.line,
+            odds=prop.odds,
+            projection=matched.projection.projection,
+            projected_probability=projected_prob,
+            implied_probability=implied_prob,
+            edge=edge_value,
+            source=matched.projection.source,
+        )
+
+    def calculate_edges(self, props: Iterable[PlayerProp]) -> pd.DataFrame:
+        """Calculate edges for a sequence of props, returning a tidy DataFrame."""
+
+        results: List[EdgeResult] = []
+        for prop in props:
+            try:
+                matched = self.match_prop(prop)
+            except MatchNotFoundError as exc:
+                LOGGER.warning("Skipping prop for %s: %s", prop.player, exc)
+                continue
+            result = self.build_edge(prop, matched)
+            results.append(result)
+        if not results:
+            raise MatchNotFoundError("No props could be matched to projections.")
+        df = pd.DataFrame([result.dict() for result in results])
+        df.sort_values(by="edge", ascending=False, inplace=True)
+        df.reset_index(drop=True, inplace=True)
+        LOGGER.info("Calculated edges for %d props", len(df))
+        return df

--- a/src/nfl_prop_agent/exceptions.py
+++ b/src/nfl_prop_agent/exceptions.py
@@ -1,0 +1,11 @@
+"""Custom exception types for the application."""
+
+from __future__ import annotations
+
+
+class DataSourceError(RuntimeError):
+    """Raised when an external data source cannot be reached or parsed."""
+
+
+class MatchNotFoundError(LookupError):
+    """Raised when no projection can be matched to a player prop."""

--- a/src/nfl_prop_agent/logging_utils.py
+++ b/src/nfl_prop_agent/logging_utils.py
@@ -1,0 +1,24 @@
+"""Centralized logging configuration helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from .config import settings
+
+
+def configure_logging(name: Optional[str] = None) -> logging.Logger:
+    """Return a logger configured with the project defaults."""
+
+    logger = logging.getLogger(name if name else "nfl_prop_agent")
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    logger.setLevel(settings.log_level.upper())
+    return logger

--- a/src/nfl_prop_agent/pipeline.py
+++ b/src/nfl_prop_agent/pipeline.py
@@ -1,0 +1,46 @@
+"""High-level orchestration helpers for building edge reports."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import pandas as pd
+
+from .data_loader import (
+    fetch_remote_csv,
+    load_props_from_dataframe,
+    load_projections_from_dataframe,
+    load_sample_props,
+    load_sample_projections,
+)
+from .data_models import PlayerProp, Projection
+from .edge_calculator import EdgeCalculator
+from .logging_utils import configure_logging
+
+LOGGER = configure_logging(__name__)
+
+
+def build_edge_report(
+    props: Sequence[PlayerProp] | None = None,
+    projections: Sequence[Projection] | None = None,
+) -> pd.DataFrame:
+    """Calculate an edge report from provided or sample data."""
+
+    prop_records = list(props) if props is not None else load_sample_props()
+    projection_records = list(projections) if projections is not None else load_sample_projections()
+    calculator = EdgeCalculator(projection_records)
+    return calculator.calculate_edges(prop_records)
+
+
+def load_props_from_url(url: str) -> Sequence[PlayerProp]:
+    """Load prop data from a CSV URL."""
+
+    df = fetch_remote_csv(url)
+    return load_props_from_dataframe(df)
+
+
+def load_projections_from_url(url: str) -> Sequence[Projection]:
+    """Load projection data from a CSV URL."""
+
+    df = fetch_remote_csv(url)
+    return load_projections_from_dataframe(df)

--- a/src/nfl_prop_agent/streamlit_app.py
+++ b/src/nfl_prop_agent/streamlit_app.py
@@ -1,0 +1,88 @@
+"""Streamlit UI for exploring player prop edges."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import pandas as pd
+import streamlit as st
+
+from .data_loader import (
+    load_props_from_dataframe,
+    load_projections_from_dataframe,
+    load_sample_props,
+    load_sample_projections,
+)
+from .data_models import PlayerProp, Projection
+from .edge_calculator import EdgeCalculator
+
+
+@st.cache_data(show_spinner=False)
+def _load_uploaded_data(uploaded_file) -> pd.DataFrame | None:
+    if uploaded_file is None:
+        return None
+    try:
+        return pd.read_csv(uploaded_file)
+    except Exception as exc:  # pragma: no cover - UI feedback path
+        st.error(f"Failed to parse uploaded CSV: {exc}")
+        return None
+
+
+def _records_from_dataframe(df: pd.DataFrame | None, loader) -> Sequence:
+    if df is None:
+        return ()
+    try:
+        return loader(df)
+    except Exception as exc:  # pragma: no cover - UI feedback path
+        st.error(str(exc))
+        return ()
+
+
+def run() -> None:
+    """Run the Streamlit application."""
+
+    st.set_page_config(page_title="NFL Prop Edge", layout="wide")
+    st.title("NFL Player Prop Edge Dashboard")
+    st.write(
+        "Upload your own sportsbook and projection CSVs to compute edges, or enjoy the bundled sample data."
+    )
+
+    st.sidebar.header("Inputs")
+    props_upload = st.sidebar.file_uploader("Sportsbook props CSV", type=["csv"], key="props")
+    projections_upload = st.sidebar.file_uploader("Projection CSV", type=["csv"], key="projections")
+    min_match_score = st.sidebar.slider("Minimum name match score", min_value=50, max_value=100, value=85)
+
+    sample_props = load_sample_props()
+    sample_projections = load_sample_projections()
+
+    props_df = _load_uploaded_data(props_upload)
+    projections_df = _load_uploaded_data(projections_upload)
+
+    props_records: Sequence[PlayerProp]
+    projections_records: Sequence[Projection]
+
+    props_records = (
+        _records_from_dataframe(props_df, load_props_from_dataframe) if props_df is not None else sample_props
+    )
+    projections_records = (
+        _records_from_dataframe(projections_df, load_projections_from_dataframe)
+        if projections_df is not None
+        else sample_projections
+    )
+
+    calculator = EdgeCalculator(projections_records, min_match_score=min_match_score)
+
+    try:
+        report = calculator.calculate_edges(props_records)
+    except Exception as exc:  # pragma: no cover - UI feedback path
+        st.error(str(exc))
+        return
+
+    st.dataframe(report, use_container_width=True)
+    st.caption(
+        "Edge is the difference between the projected over probability (logistic transform) and implied odds probability."
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution hook
+    run()

--- a/src/pandas/__init__.py
+++ b/src/pandas/__init__.py
@@ -1,0 +1,97 @@
+"""Lightweight stand-in for pandas used in restricted execution environments."""
+
+from __future__ import annotations
+
+import csv
+from io import StringIO, TextIOBase
+from pathlib import Path
+from typing import Any, Iterable, List, Mapping, Sequence
+
+PathLike = str | Path
+
+
+class DataFrame:
+    """Minimal tabular data structure supporting the operations required by the project."""
+
+    def __init__(self, data: Iterable[Mapping[str, Any]] | None = None):
+        rows = [dict(row) for row in data] if data is not None else []
+        self._rows: List[dict[str, Any]] = rows
+        self._columns: List[str] = list(rows[0].keys()) if rows else []
+
+    @property
+    def columns(self) -> List[str]:
+        return list(self._columns)
+
+    def __len__(self) -> int:
+        return len(self._rows)
+
+    def __iter__(self):
+        return iter(self._rows)
+
+    def __getitem__(self, item: Sequence[str] | str):
+        if isinstance(item, list):
+            return DataFrame([{column: row.get(column) for column in item} for row in self._rows])
+        if isinstance(item, str):
+            return [row.get(item) for row in self._rows]
+        raise TypeError("Unsupported index type for DataFrame.__getitem__")
+
+    def to_dict(self, orient: str = "records") -> List[dict[str, Any]]:
+        if orient != "records":
+            raise ValueError("Only 'records' orient is supported in this lightweight implementation.")
+        return [dict(row) for row in self._rows]
+
+    def sort_values(self, by: str, ascending: bool = True, inplace: bool = False):
+        sorted_rows = sorted(self._rows, key=lambda row: row.get(by), reverse=not ascending)
+        if inplace:
+            self._rows = sorted_rows
+            return None
+        return DataFrame(sorted_rows)
+
+    def reset_index(self, drop: bool = False, inplace: bool = False):
+        if inplace:
+            return None
+        return self
+
+    def to_string(self, index: bool = True) -> str:
+        if not self._rows:
+            return ""
+        headers = self._columns
+        rows = [" | ".join(headers)]
+        for row in self._rows:
+            rows.append(" | ".join(str(row.get(column, "")) for column in headers))
+        return "\n".join(rows)
+
+    def to_csv(self, path: PathLike, index: bool = False) -> None:
+        with open(path, "w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=self._columns)
+            writer.writeheader()
+            for row in self._rows:
+                writer.writerow({column: row.get(column) for column in self._columns})
+
+    @property
+    def iloc(self) -> "_ILocAccessor":
+        return _ILocAccessor(self._rows)
+
+
+class _ILocAccessor:
+    def __init__(self, rows: List[dict[str, Any]]):
+        self._rows = rows
+
+    def __getitem__(self, index: int) -> dict[str, Any]:
+        return self._rows[index]
+
+
+def read_csv(path_or_buffer: PathLike | TextIOBase | StringIO) -> DataFrame:
+    """Parse CSV data from a file path or file-like object into a :class:`DataFrame`."""
+
+    if isinstance(path_or_buffer, (str, Path)):
+        with open(path_or_buffer, "r", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            return DataFrame(reader)
+    if hasattr(path_or_buffer, "read"):
+        text = path_or_buffer.read()
+        if isinstance(text, bytes):
+            text = text.decode("utf-8")
+        reader = csv.DictReader(StringIO(text))
+        return DataFrame(reader)
+    raise TypeError("Unsupported type for read_csv")

--- a/src/prop_model/__init__.py
+++ b/src/prop_model/__init__.py
@@ -1,0 +1,5 @@
+"""Core configuration and utilities for the prop model package."""
+
+from . import config as config  # re-export for convenience
+
+__all__ = ["config"]

--- a/src/prop_model/config.py
+++ b/src/prop_model/config.py
@@ -1,0 +1,62 @@
+"""Static configuration for the prop model application."""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Sportsbooks we include when calculating market averages and consensus lines.
+MA_BOOKS: Final[list[str]] = [
+    "DraftKings",
+    "FanDuel",
+    "BetMGM",
+    "Caesars",
+    "ESPN BET",
+    "Fanatics",
+    "Bally Bet",
+]
+
+# Player prop market identifiers supported by the analytics toolkit.
+MARKETS: Final[list[str]] = [
+    "player_pass_yds",
+    "player_pass_tds",
+    "player_pass_interceptions",
+    "player_rush_yds",
+    "player_rush_tds",
+    "player_receptions",
+    "player_reception_yds",
+    "player_reception_tds",
+    "player_goal_scorer_anytime",
+]
+
+# Minimum American odds (e.g., heavy favorite) allowed when ingesting lines.
+ODDS_MIN: Final[int] = -200
+# Maximum American odds (e.g., longshot) allowed when ingesting lines.
+ODDS_MAX: Final[int] = 500
+
+# Minimum number of books that must post a line before evaluating the prop.
+MIN_BOOKS: Final[int] = 3
+# Highest acceptable combined vig when consolidating market prices.
+MAX_VIG: Final[float] = 0.06
+
+# Minimum expected value to flag props for a shortlist review.
+SHORTLIST_EV: Final[float] = 0.03
+# Minimum expected value to issue a betting recommendation.
+RECOMMEND_EV: Final[float] = 0.05
+# Z-score threshold for highlighting moderate yardage edges.
+Z_YARDS: Final[float] = 0.40
+# Z-score threshold for highlighting strong yardage edges.
+Z_YARDS_STRONG: Final[float] = 0.65
+# Z-score threshold for highlighting moderate reception edges.
+Z_REC: Final[float] = 0.55
+# Z-score threshold for highlighting strong reception edges.
+Z_REC_STRONG: Final[float] = 0.80
+
+# Total bankroll units assumed for staking calculations.
+BANKROLL_UNITS: Final[int] = 100
+# Fraction of the Kelly stake to deploy for recommended bets.
+KELLY_MULTIPLIER: Final[float] = 0.5
+
+# Injury statuses that lead us to drop the prop entirely.
+INJURY_DROP_STATUSES: Final[set[str]] = {"OUT", "SUSP"}
+# Injury statuses that instruct the staking model to halve the wager size.
+INJURY_HALF_STATUSES: Final[set[str]] = {"Q", "D"}

--- a/src/pydantic/__init__.py
+++ b/src/pydantic/__init__.py
@@ -1,0 +1,134 @@
+"""A tiny subset of Pydantic tailored for this project."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Tuple, Type
+
+
+_MISSING = object()
+
+
+@dataclass
+class FieldInfo:
+    default: Any = _MISSING
+    default_factory: Callable[[], Any] | None = None
+    ge: float | None = None
+    le: float | None = None
+    gt: float | None = None
+    lt: float | None = None
+    description: str | None = None
+
+
+def Field(default: Any = _MISSING, *, default_factory: Callable[[], Any] | None = None, **kwargs: Any) -> FieldInfo:
+    return FieldInfo(default=default, default_factory=default_factory, **kwargs)
+
+
+def validator(*fields: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        setattr(func, "_validator_fields", fields)
+        return func
+
+    return decorator
+
+
+def _cast_value(value: Any, annotation: Any) -> Any:
+    if isinstance(annotation, str):
+        mapping = {"int": int, "float": float, "str": str}
+        annotation = mapping.get(annotation, None)
+        if annotation is None:
+            return value
+    try:
+        if annotation in (int, float, str):
+            return annotation(value)
+        if annotation.__name__ == "Path":
+            from pathlib import Path
+
+            return Path(value)
+    except Exception:
+        return value
+    return value
+
+
+class _BaseModelMeta(type):
+    def __new__(mcls, name: str, bases: Tuple[type, ...], namespace: Dict[str, Any]):
+        annotations = namespace.get("__annotations__", {})
+        validators: List[Tuple[Tuple[str, ...], Callable[..., Any]]] = []
+        for attr_name, attr_value in list(namespace.items()):
+            fields = getattr(attr_value, "_validator_fields", None)
+            if fields:
+                validators.append((fields, attr_value))
+        namespace["__validators__"] = validators
+        fields: Dict[str, FieldInfo] = {}
+        for field_name, annotation in annotations.items():
+            default = namespace.get(field_name, _MISSING)
+            if isinstance(default, FieldInfo):
+                fields[field_name] = default
+                namespace.pop(field_name, None)
+            elif default is _MISSING:
+                fields[field_name] = FieldInfo()
+            else:
+                fields[field_name] = FieldInfo(default=default)
+        namespace["__fields__"] = fields
+        namespace["__annotations__"] = annotations
+        return super().__new__(mcls, name, bases, namespace)
+
+
+class BaseModel(metaclass=_BaseModelMeta):
+    __fields__: Dict[str, FieldInfo]
+    __validators__: List[Tuple[Tuple[str, ...], Callable[..., Any]]]
+    __annotations__: Dict[str, Any]
+
+    def __init__(self, **data: Any) -> None:
+        values: Dict[str, Any] = {}
+        for name, info in self.__fields__.items():
+            if name in data:
+                value = data[name]
+            elif info.default is not _MISSING:
+                value = info.default
+            elif info.default_factory is not None:
+                value = info.default_factory()
+            else:
+                raise TypeError(f"Missing required field '{name}'")
+            annotation = self.__annotations__.get(name)
+            if annotation is not None:
+                value = _cast_value(value, annotation)
+            if info.ge is not None and value < info.ge:
+                raise ValueError(f"Field {name} must be >= {info.ge}")
+            if info.le is not None and value > info.le:
+                raise ValueError(f"Field {name} must be <= {info.le}")
+            if info.gt is not None and value <= info.gt:
+                raise ValueError(f"Field {name} must be > {info.gt}")
+            if info.lt is not None and value >= info.lt:
+                raise ValueError(f"Field {name} must be < {info.lt}")
+            values[name] = value
+        for fields, validator_fn in self.__validators__:
+            for field_name in fields:
+                if field_name in values:
+                    values[field_name] = validator_fn(self.__class__, values[field_name])
+        for name, value in values.items():
+            setattr(self, name, value)
+
+    def dict(self) -> Dict[str, Any]:
+        return {name: getattr(self, name) for name in self.__fields__}
+
+
+class BaseSettings(BaseModel):
+    class Config:
+        env_prefix = ""
+        case_sensitive = True
+
+    def __init__(self, **values: Any) -> None:
+        config = getattr(self, "Config", BaseSettings.Config)
+        prefix = getattr(config, "env_prefix", "")
+        case_sensitive = getattr(config, "case_sensitive", True)
+        for field_name in self.__fields__:
+            env_key = prefix + field_name
+            if not case_sensitive:
+                env_key = env_key.upper()
+            env_value = os.getenv(env_key)
+            if env_value is not None and field_name not in values:
+                annotation = self.__annotations__.get(field_name)
+                values[field_name] = _cast_value(env_value, annotation)
+        super().__init__(**values)

--- a/src/rapidfuzz/__init__.py
+++ b/src/rapidfuzz/__init__.py
@@ -1,0 +1,27 @@
+"""Simplified RapidFuzz replacements used for deterministic testing."""
+
+from __future__ import annotations
+
+from difflib import SequenceMatcher
+from typing import Iterable, Sequence, Tuple
+
+
+def _ratio(a: str, b: str) -> float:
+    return SequenceMatcher(None, a.lower(), b.lower()).ratio() * 100
+
+
+class fuzz:
+    @staticmethod
+    def WRatio(a: str, b: str) -> float:
+        return _ratio(a, b)
+
+
+class process:
+    @staticmethod
+    def extractOne(query: str, choices: Sequence[str], scorer=fuzz.WRatio) -> Tuple[str, float, int] | None:
+        best: Tuple[str, float, int] | None = None
+        for index, choice in enumerate(choices):
+            score = scorer(query, choice)
+            if best is None or score > best[1]:
+                best = (choice, score, index)
+        return best

--- a/src/requests/__init__.py
+++ b/src/requests/__init__.py
@@ -1,0 +1,33 @@
+"""Minimal subset of the requests API using urllib under the hood."""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+
+class RequestException(Exception):
+    """Base exception for HTTP errors."""
+
+
+@dataclass
+class Response:
+    status_code: int
+    text: str
+
+    def raise_for_status(self) -> None:
+        if 400 <= self.status_code:
+            raise RequestException(f"HTTP {self.status_code}")
+
+
+def get(url: str, timeout: float | None = None) -> Response:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as handle:
+            status = getattr(handle, "status", 200)
+            text = handle.read().decode("utf-8")
+            return Response(status_code=status, text=text)
+    except urllib.error.HTTPError as exc:  # pragma: no cover - passthrough
+        raise RequestException(str(exc)) from exc
+    except urllib.error.URLError as exc:  # pragma: no cover - passthrough
+        raise RequestException(str(exc)) from exc

--- a/src/streamlit/__init__.py
+++ b/src/streamlit/__init__.py
@@ -1,0 +1,59 @@
+"""Streamlit stubs enabling local execution without the real library."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+def cache_data(show_spinner: bool | None = None) -> Callable:
+    def decorator(func: Callable) -> Callable:
+        return func
+
+    return decorator
+
+
+def set_page_config(**kwargs: Any) -> None:  # pragma: no cover - no-op
+    pass
+
+
+def title(text: str) -> None:  # pragma: no cover - placeholder
+    print(text)
+
+
+def write(text: str) -> None:  # pragma: no cover - placeholder
+    print(text)
+
+
+def dataframe(data: Any, use_container_width: bool = False) -> None:  # pragma: no cover - placeholder
+    print("DataFrame:")
+    print(getattr(data, "to_string", lambda **_: str(data))())
+
+
+def caption(text: str) -> None:  # pragma: no cover - placeholder
+    print(text)
+
+
+def error(text: str) -> None:  # pragma: no cover - placeholder
+    print(f"ERROR: {text}")
+
+
+@dataclass
+class _Sidebar:
+    def header(self, text: str) -> None:  # pragma: no cover - placeholder
+        print(text)
+
+    def file_uploader(self, label: str, type: list[str] | None = None, key: str | None = None):  # pragma: no cover - stub
+        return None
+
+    def slider(
+        self,
+        label: str,
+        min_value: int,
+        max_value: int,
+        value: int,
+    ) -> int:  # pragma: no cover - stub
+        return value
+
+
+sidebar = _Sidebar()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest configuration for local imports."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_edge_calculator.py
+++ b/tests/test_edge_calculator.py
@@ -1,0 +1,90 @@
+"""Unit tests for edge calculation logic."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from nfl_prop_agent.data_models import PlayerProp, Projection
+from nfl_prop_agent.edge_calculator import EdgeCalculator, american_to_implied_prob, logistic_probability
+
+
+@pytest.fixture()
+def sample_props() -> list[PlayerProp]:
+    return [
+        PlayerProp(
+            player="Patrick Mahomes II",
+            team="KC",
+            market="passing_yards",
+            line=285.5,
+            odds=-110,
+            sportsbook="DraftKings",
+        ),
+        PlayerProp(
+            player="Josh Allen",
+            team="BUF",
+            market="passing_yards",
+            line=270.5,
+            odds=-105,
+            sportsbook="FanDuel",
+        ),
+    ]
+
+
+@pytest.fixture()
+def sample_projections() -> list[Projection]:
+    return [
+        Projection(
+            player="Patrick Mahomes",
+            team="KC",
+            market="passing_yards",
+            projection=301.2,
+            source="Model A",
+        ),
+        Projection(
+            player="Josh Allen",
+            team="BUF",
+            market="passing_yards",
+            projection=283.4,
+            source="Model A",
+        ),
+    ]
+
+
+def test_american_odds_conversion() -> None:
+    assert math.isclose(american_to_implied_prob(-110), 110 / 210, rel_tol=1e-6)
+    assert math.isclose(american_to_implied_prob(130), 100 / 230, rel_tol=1e-6)
+
+
+def test_logistic_probability_is_half_when_equal() -> None:
+    assert math.isclose(logistic_probability(100.0, 100.0, slope=0.5), 0.5, rel_tol=1e-6)
+
+
+def test_calculate_edges_orders_by_value(sample_props: list[PlayerProp], sample_projections: list[Projection]) -> None:
+    calculator = EdgeCalculator(sample_projections, min_match_score=70)
+    report = calculator.calculate_edges(sample_props)
+    assert list(report.columns) == [
+        "player",
+        "matched_player",
+        "match_score",
+        "team",
+        "market",
+        "sportsbook",
+        "line",
+        "odds",
+        "projection",
+        "projected_probability",
+        "implied_probability",
+        "edge",
+        "source",
+    ]
+    assert report.iloc[0]["player"] == "Patrick Mahomes II"
+    assert report.iloc[0]["edge"] >= report.iloc[1]["edge"]
+
+
+def test_high_threshold_filters(sample_props: list[PlayerProp], sample_projections: list[Projection]) -> None:
+    calculator = EdgeCalculator(sample_projections, min_match_score=99)
+    report = calculator.calculate_edges(sample_props)
+    assert len(report) == 1
+    assert report.iloc[0]["player"] == "Josh Allen"


### PR DESCRIPTION
## Summary
- add a dedicated prop_model package that exposes configuration constants
- document sportsbook, odds, market, and injury handling thresholds in config

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd63a9537c83268ed4d153b6057d90