### PR TITLE
Add sample projections data and update setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy to .env and replace with your real Odds API key
+ODDS_API_KEY=
+
+# Optional overrides consumed by nfl_prop_agent
+# NFL_PROP_MIN_MATCH_SCORE=85
+# NFL_PROP_LOGISTIC_SLOPE=0.08
+# NFL_PROP_LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -16,47 +16,72 @@ A modular, testable Python project for analyzing NFL player prop markets. The to
 
 ## Getting Started
 
-### Installation
+### Setup
 
 ```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -e .
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env  # add ODDS_API_KEY
 ```
 
-### Environment Variables
-
-Configuration values can be supplied through environment variables using a `.env` file. All keys are prefixed with `NFL_PROP_`. Notable options:
-
-- `NFL_PROP_MIN_MATCH_SCORE`: Override the default minimum RapidFuzz score (85).
-- `NFL_PROP_LOGISTIC_SLOPE`: Adjust the logistic probability slope.
-- `NFL_PROP_LOG_LEVEL`: Logging level (default `INFO`).
+The `.env` file is used by both the CLI and the Streamlit app. Populate it with your Odds API key and any optional
+`NFL_PROP_*` overrides such as `NFL_PROP_MIN_MATCH_SCORE`, `NFL_PROP_LOGISTIC_SLOPE`, or `NFL_PROP_LOG_LEVEL`.
 
 ### CLI Usage
 
-Generate an edge report using the bundled sample data:
+- **Quick start:** run `python -m nfl_prop_agent.cli` to calculate edges using the bundled sample datasets.
+- **Custom inputs:** supply CSV URLs for sportsbook props and projections. The command below uses an absolute output path
+  so you can see a "real" file location in the working tree.
 
-```bash
-python -m nfl_prop_agent.cli
-```
-
-Specify custom CSV URLs and write the report to disk:
-
-```bash
-python -m nfl_prop_agent.cli --props-url https://example.com/props.csv \
+  ```bash
+  python -m nfl_prop_agent.cli \
+    --props-url https://example.com/props.csv \
     --projections-url https://example.com/projections.csv \
-    --output report.csv
-```
+    --output $(pwd)/reports/week01_edges.csv
+  ```
 
-CSV headers must match the columns in the sample data found in `src/nfl_prop_agent/data/`.
+  The CLI expects HTTP(S) URLs—host local files with a lightweight server (for example `python -m http.server`) before
+  pointing the flags at them. CSV headers must match the samples in `src/nfl_prop_agent/data/` and the additional
+  projections provided in `data/sample_projections.csv`.
 
-### Streamlit App
+### Streamlit Usage
+
+Launch the live workflow locally:
 
 ```bash
-streamlit run src/nfl_prop_agent/streamlit_app.py
+streamlit run app.py
 ```
 
-Upload sportsbook and projection CSVs or rely on the bundled samples to visualize calculated edges.
+The app loads projections via `prop_model.io`, fetches odds from The Odds API, and publishes summaries plus Slack-ready
+messages.
+
+### How to add name overrides
+
+Manual overrides help reconcile players who are tough to match via fuzzy logic. Create `data/manual_overrides.csv` with
+the exact columns `player_left,team_left,pos_left,player_right,team_right,pos_right`. Each row describes how a record
+from the sportsbook feed (`*_left`) should be rewritten to line up with your projection feed (`*_right`). The
+`prop_model.mapping` module automatically loads the file, normalises the names/teams/positions, and uses the override
+when calculating join pairs. Restart the CLI or Streamlit session after editing the CSV so the changes are picked up.
+
+### Notes on rate limits & retries
+
+- The Odds API endpoints are queried with exponential backoff (up to five attempts) whenever HTTP errors or rate limits
+  occur. `Retry-After` headers are honoured, and failures are logged so you can monitor noisy conditions.
+- Respect the vendor’s quota—large batch jobs should be staggered or cached locally to avoid repeated fetches.
+- When rate limits are hit repeatedly, expect increased latency inside the Streamlit app while the retry logic sleeps.
+
+### Troubleshooting FAQ
+
+- **No odds returned:** confirm `ODDS_API_KEY` is present and valid, verify the requested markets exist in
+  `prop_model.config.MARKETS`, and check The Odds API status page for outages.
+- **Unmatched player names:** ensure both feeds share markets, update `data/manual_overrides.csv`, or lower the
+  `NFL_PROP_MIN_MATCH_SCORE` environment variable for more permissive fuzzy matching.
+- **Missing projection standard deviation:** the staking model requires `*_sd` columns (for example `rush_yds_sd`). If a
+  feed does not provide them, fill the values manually or drop the affected market before running reports.
+- **CLI errors when pointing to local files:** the CLI downloads from URLs. Start a simple HTTP server in the directory
+  that contains your CSVs (`python -m http.server 8000`) and use `http://localhost:8000/...` paths instead of `file://`.
+- **Streamlit session looks stale:** click the “Clear cache” button in the app sidebar or rerun the script to ensure new
+  odds/projections are loaded.
 
 ### Tests
 

--- a/data/sample_projections.csv
+++ b/data/sample_projections.csv
@@ -1,0 +1,9 @@
+player,team,market,projection,source
+Patrick Mahomes,KC,passing_yards,304.5,Model Composite
+Josh Allen,BUF,passing_yards,287.1,Model Composite
+Lamar Jackson,BAL,rushing_yards,65.3,Model Composite
+Christian McCaffrey,SF,rushing_yards,88.7,Model Composite
+Justin Jefferson,MIN,receiving_yards,103.9,Model Composite
+Tyreek Hill,MIA,receiving_yards,108.4,Model Composite
+Travis Kelce,KC,receiving_yards,82.6,Model Composite
+Amon-Ra St. Brown,DET,receiving_yards,94.2,Model Composite

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pandas>=2.1
+requests>=2.31
+pydantic>=1.10,<3
+rapidfuzz>=3.1
+python-dotenv>=1.0
+streamlit>=1.29
+-e .


### PR DESCRIPTION
## Summary
- add a standalone sample projections CSV for quick experimentation
- refresh the README with setup, CLI, override, rate limit, and troubleshooting guidance
- provide supporting files for setup, including requirements.txt and .env.example

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd85405b448326b486b89c59e2568b