### PR TITLE
Simplify package init

### DIFF
--- a/src/nfl_prop_agent/__init__.py
+++ b/src/nfl_prop_agent/__init__.py
@@ -1,7 +1,4 @@
 """Top-level package for the NFL prop edge toolkit."""
 
-from .config import settings
-from .edge_calculator import EdgeCalculator
-from .streamlit_app import run as run_app
-
-__all__ = ["settings", "EdgeCalculator", "run_app"]
+# Avoid importing heavy modules or settings here to keep `--help` fast/safe.
+__all__ = []


### PR DESCRIPTION
## Summary
- remove heavy imports from the package __init__ module to keep CLI help fast
- leave an empty __all__ to avoid re-exporting objects by default

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd8bb758cc83268814e21f01686cbd