### PR TITLE
Update config module to Pydantic v2

### DIFF
--- a/src/nfl_prop_agent/config.py
+++ b/src/nfl_prop_agent/config.py
@@ -1,56 +1,100 @@
-"""Application configuration and environment loading utilities."""
+"""Application configuration and environment loading utilities (Pydantic v2)."""
 
 from __future__ import annotations
 
 import logging
 from functools import lru_cache
 from pathlib import Path
+from typing import Literal, Optional
 
-try:  # pragma: no cover - fallback for limited environments
-    from dotenv import load_dotenv
-except ModuleNotFoundError:  # pragma: no cover - fallback for limited environments
-    def load_dotenv(*args, **kwargs):
-        logging.getLogger(__name__).warning(
-            "python-dotenv is not installed; environment variables from .env will not be loaded."
-        )
-from pydantic import BaseSettings, Field, validator
+from dotenv import load_dotenv
+from pydantic import Field, field_validator, computed_field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
-load_dotenv()
+log = logging.getLogger(__name__)
+load_dotenv(dotenv_path=Path(".env"), override=False)
+
+MA_BOOKS_DEFAULT = [
+    "DraftKings",
+    "FanDuel",
+    "BetMGM",
+    "Caesars",
+    "ESPN BET",
+    "Fanatics",
+    "Bally Bet",
+]
+
+MARKETS_DEFAULT = [
+    "player_pass_yds",
+    "player_pass_tds",
+    "player_pass_interceptions",
+    "player_rush_yds",
+    "player_rush_tds",
+    "player_receptions",
+    "player_reception_yds",
+    "player_reception_tds",
+    "player_goal_scorer_anytime",
+]
 
 
 class Settings(BaseSettings):
-    """Configuration values read from environment variables."""
+    """Runtime settings loaded from environment and sane defaults."""
 
-    data_directory: Path = Field(
-        default_factory=lambda: Path(__file__).resolve().parent / "data",
-        description="Directory containing bundled CSV data files.",
-    )
-    min_match_score: int = Field(85, ge=0, le=100, description="Minimum RapidFuzz score to consider a player match valid.")
-    logistic_slope: float = Field(
-        0.08,
-        gt=0.0,
-        description="Slope parameter for logistic projection probability conversion.",
-    )
-    http_timeout: float = Field(5.0, gt=0.0, description="Timeout in seconds for outbound HTTP requests.")
-    log_level: str = Field("INFO", description="Python logging level for the application.")
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
-    class Config:
-        env_prefix = "NFL_PROP_"
-        case_sensitive = False
+    # API / external
+    ODDS_API_KEY: Optional[str] = Field(default=None, description="The Odds API key")
 
-    @validator("data_directory")
-    def _ensure_data_directory(cls, value: Path) -> Path:
-        if not value.exists():
-            logging.getLogger(__name__).warning("Data directory %s does not exist; creating it.", value)
-            value.mkdir(parents=True, exist_ok=True)
-        return value
+    # Filters
+    MA_BOOKS: list[str] = Field(default_factory=lambda: MA_BOOKS_DEFAULT.copy())
+    MARKETS: list[str] = Field(default_factory=lambda: MARKETS_DEFAULT.copy())
+
+    # Guardrails
+    ODDS_MIN: int = Field(default=-200)     # ignore shorter than -200
+    ODDS_MAX: int = Field(default=500)      # ignore longer than +500
+    MIN_BOOKS: int = Field(default=3)
+    MAX_VIG: float = Field(default=0.06)
+
+    # Thresholds
+    SHORTLIST_EV: float = Field(default=0.03)
+    RECOMMEND_EV: float = Field(default=0.05)
+    Z_YARDS: float = Field(default=0.40)
+    Z_YARDS_STRONG: float = Field(default=0.65)
+    Z_REC: float = Field(default=0.55)
+    Z_REC_STRONG: float = Field(default=0.80)
+
+    # Bankroll
+    BANKROLL_UNITS: float = Field(default=100.0)
+    KELLY_MULTIPLIER: float = Field(default=0.5)
+
+    # IO
+    OUT_DIR: Path = Field(default_factory=lambda: Path("out"))
+    DATA_DIR: Path = Field(default_factory=lambda: Path("data"))
+
+    # Slack
+    SLACK_WEBHOOK_URL: Optional[str] = Field(default=None)
+
+    @field_validator("OUT_DIR", "DATA_DIR", mode="before")
+    @classmethod
+    def _ensure_path(cls, v: str | Path) -> Path:
+        p = Path(v)
+        if not p.exists():
+            try:
+                p.mkdir(parents=True, exist_ok=True)
+            except Exception as exc:  # pragma: no cover
+                log.warning("Could not create directory %s: %s", p, exc)
+        return p
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def MA_BOOKS_SET(self) -> set[str]:
+        return {b.lower() for b in self.MA_BOOKS}
 
 
 @lru_cache()
 def get_settings() -> Settings:
-    """Return a cached :class:`Settings` instance."""
-
-    return Settings()  # type: ignore[call-arg]
+    return Settings()
 
 
+# Lazy, global accessor (do NOT import this in __init__)
 settings: Settings = get_settings()


### PR DESCRIPTION
## Summary
- replace the configuration module with a Pydantic v2 implementation
- load .env settings using pydantic-settings SettingsConfigDict configuration
- add helpers for default sportsbooks, markets, and derived MA_BOOKS_SET property

## Testing
- pytest *(fails: missing optional dependencies `pydantic_settings` and `prop_model`)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8c0d49c083269bef045df3c396e1