### PR TITLE
Delay settings loading until runtime

### DIFF
--- a/src/nfl_prop_agent/data_loader.py
+++ b/src/nfl_prop_agent/data_loader.py
@@ -8,7 +8,7 @@ from typing import Iterable, List
 import pandas as pd
 import requests
 
-from .config import settings
+from .config import get_settings
 from .data_models import PlayerProp, Projection
 from .exceptions import DataSourceError
 from .logging_utils import configure_logging
@@ -19,6 +19,7 @@ LOGGER = configure_logging(__name__)
 def load_local_csv(filename: str) -> pd.DataFrame:
     """Load a CSV file bundled with the package into a :class:`pandas.DataFrame`."""
 
+    settings = get_settings()
     path = settings.data_directory / filename
     if not path.exists():
         raise DataSourceError(f"Expected data file {path} was not found.")
@@ -29,6 +30,7 @@ def load_local_csv(filename: str) -> pd.DataFrame:
 def fetch_remote_csv(url: str) -> pd.DataFrame:
     """Fetch a CSV file from a remote URL, raising :class:`DataSourceError` on failure."""
 
+    settings = get_settings()
     LOGGER.info("Fetching remote CSV from %s", url)
     try:
         response = requests.get(url, timeout=settings.http_timeout)

--- a/src/nfl_prop_agent/edge_calculator.py
+++ b/src/nfl_prop_agent/edge_calculator.py
@@ -9,7 +9,7 @@ from typing import Iterable, List, Sequence
 import pandas as pd
 from rapidfuzz import fuzz, process
 
-from .config import settings
+from .config import get_settings
 from .data_models import EdgeResult, PlayerProp, Projection
 from .exceptions import MatchNotFoundError
 from .logging_utils import configure_logging
@@ -33,7 +33,7 @@ def american_to_implied_prob(odds: int) -> float:
 def logistic_probability(line: float, projection: float, slope: float | None = None) -> float:
     """Approximate the over hit probability using a logistic transform."""
 
-    slope_value = slope if slope is not None else settings.logistic_slope
+    slope_value = slope if slope is not None else get_settings().logistic_slope
     diff = projection - line
     prob = 1.0 / (1.0 + math.exp(-slope_value * diff))
     LOGGER.debug(
@@ -60,7 +60,10 @@ class EdgeCalculator:
         self._projections = list(projections)
         if not self._projections:
             raise ValueError("At least one projection is required to build EdgeCalculator.")
-        self._min_match_score = min_match_score if min_match_score is not None else settings.min_match_score
+        settings = get_settings()
+        self._min_match_score = (
+            min_match_score if min_match_score is not None else settings.min_match_score
+        )
         LOGGER.info(
             "EdgeCalculator initialized with %d projections and min_match_score=%d",
             len(self._projections),

--- a/src/nfl_prop_agent/logging_utils.py
+++ b/src/nfl_prop_agent/logging_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from .config import settings
+from .config import get_settings
 
 
 def configure_logging(name: Optional[str] = None) -> logging.Logger:
@@ -20,5 +20,6 @@ def configure_logging(name: Optional[str] = None) -> logging.Logger:
         )
         handler.setFormatter(formatter)
         logger.addHandler(handler)
+    settings = get_settings()
     logger.setLevel(settings.log_level.upper())
     return logger


### PR DESCRIPTION
## Summary
- replace module-level settings imports with runtime calls to `get_settings` in data loading, logging, and edge calculations to avoid eager configuration loading

## Testing
- pytest *(fails: missing pydantic_settings and prop_model dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8ccb9f6c83268869178d28df115f